### PR TITLE
Fixes compatibility with GCC 6.3.0

### DIFF
--- a/tools/osrom2elf/osrom2elf.c
+++ b/tools/osrom2elf/osrom2elf.c
@@ -27,9 +27,9 @@ typedef enum {
         CONV_OSROM2ELF
 } conv_mode;
 
-const int OSROM_SIZE = 1024*1024;
-const int OSROM_DATA_OFFSET = sizeof(OSROM_Hdr);
-const int OSROM_DATA_SIZE = OSROM_SIZE - OSROM_DATA_OFFSET;
+#define OSROM_SIZE  (1024*1024)
+#define OSROM_DATA_OFFSET sizeof(OSROM_Hdr)
+#define OSROM_DATA_SIZE  (OSROM_SIZE - OSROM_DATA_OFFSET)
 
 /*
  * Load an OSROM file in memory.


### PR DESCRIPTION
This fixes compatibility with GCC 6.3.0 by using preprocessor instead of consts for size offsets in osrom2elf.  Closes bug #1.